### PR TITLE
Update unlicensed_games.csv

### DIFF
--- a/_data/unlicensed_games.csv
+++ b/_data/unlicensed_games.csv
@@ -1,132 +1,132 @@
 title,publisher,year,hidden
-2-in-1 Cosmocop / Cyber Monster,Sachen,1993,false
-2-in-1 Tough Cop / Super Tough Cop,Sachen,1993,false
-2 Turn Pair,Hwang Shinwei,1991,false
-3D Block,Hwang Shinwei,1989,false
+2-in-1 Cosmocop / Cyber Monster,Sachen,1993,true
+2-in-1 Tough Cop / Super Tough Cop,Sachen,1993,true
+2 Turn Pair,Hwang Shinwei,1991,true
+3D Block,Hwang Shinwei,1989,true
 Action 52,Active Enterprises,1991,false
 The Adventures of Captain Comic,Color Dreams,1989,false
 After Burner,Tengen,1989,false
 Alien Syndrome,Tengen,1989,false
-Auto Upturn,Sachen,1991,false
+Auto Upturn,Sachen,1991,true
 Baby Boomer,Color Dreams,1989,false
-BB Car,Hwang Shinwei,1991,false
+BB Car,Hwang Shinwei,1991,true
 Bee 52,Camerica,1992,false
 Bible Adventures,Wisdom Tree,1991,false
 Bible Buffet,Wisdom Tree,1993,false
 Big Nose Freaks Out,Camerica,1992,false
 Big Nose the Caveman,Camerica,1991,false
-Bingo 75,Sachen,1990,false
+Bingo 75,Sachen,1990,true
 Blackjack,American Video Entertainment,1992,false
-Block Force,Hwang Shinwei,1990,false
-Brush Roller,Hwang Shinwei,1990,false
+Block Force,Hwang Shinwei,1990,true
+Brush Roller,Hwang Shinwei,1990,true
 Bubble Bath Babes,Panesian,1991,false
 Caltron 6 in 1,Caltron,1992,false
 Castle of Deceit,Bunch Games,1990,false
 Challenge of the Dragon,Color Dreams,1990,false
-Chess Academy,Sachen,1991,false
+Chess Academy,Sachen,1991,true
 Chiller,"American Game Cartridges (NA)
 HES (AU)",1990,false
-China Chess,Hwang Shinwei,Unknown,false
-Chinese Checkers,Sachen,1991,false
-Chinese Kung Fu,Sachen,1989,false
+China Chess,Hwang Shinwei,Unknown,true
+Chinese Checkers,Sachen,1991,true
+Chinese Kung Fu,Sachen,1989,true
 Crystal Mines,Color Dreams,1989,false
-Dancing Block,Sachen,1990,false
+Dancing Block,Sachen,1990,true
 Death Race,American Game Cartridges,1990,false
 Deathbots,American Video Entertainment,1990,false
-Decathlon,C&E,1992,false
+Decathlon,C&E,1992,true
 Dizzy the Adventurer,Codemasters,1993,false
 Double Strike,"American Video Entertainment (NA)
 HES (AU)",1990,false
-Dragon Ball Z 5,SuperTone Electronics,1995,false
-Duck Maze,HES,1990,false
+Dragon Ball Z 5,SuperTone Electronics,1995,true
+Duck Maze,HES,1990,true
 Dudes with Attitude,American Video Entertainment,1990,false
-Elfland,Tip Top,1992,false
+Elfland,Tip Top,1992,true
 Exodus,Wisdom Tree,1991,false
 F-15 City War,"American Video Entertainment (NA)
 HES (AU)",1990,false
-F18 Race,Hwang Shinwei,1990,false
+F18 Race,Hwang Shinwei,1990,true
 The Fantastic Adventures of Dizzy,"Camerica (NA)
 Codemasters (EU)",1991,false
 Fantasy Zone,Tengen,1989,false
-Feng Shen Bang,C&E,1995,false
-Final Combat,Sachen,1992,false
+Feng Shen Bang,C&E,1995,true
+Final Combat,Sachen,1992,true
 Firehawk,Camerica,1991,false
-Frog Adventure,Sachen,1992,false
-Frog River,Hwang Shinwei,1990,false
-Gaiapolis,Sachen,1990,false
+Frog Adventure,Sachen,1992,true
+Frog River,Hwang Shinwei,1990,true
+Gaiapolis,Sachen,1990,true
 Galactic Crusader,Bunch Games,1990,false
 Gauntlet,Tengen,1989,false
-Gluk the Thunder Warrior,Gluk,1992,false
-The Great Wall,Sachen,1992,false
-Happy Pairs,Sachen,1991,false
-Hell Fighter,Sachen,1991,false
-Hidden Chinese Chess,Joy Van,1989,false
-Honey Peach,Sachen,1990,false
+Gluk the Thunder Warrior,Gluk,1992,true
+The Great Wall,Sachen,1992,true
+Happy Pairs,Sachen,1991,true
+Hell Fighter,Sachen,1991,true
+Hidden Chinese Chess,Joy Van,1989,true
+Honey Peach,Sachen,1990,true
 Hot Slots,Panesian,1991,false
-Huge Insect,Sachen,1993,false
+Huge Insect,Sachen,1993,true
 Impossible Mission II,American Video Entertainment,1990,false
-Incantation,Joy Van,1989,false
+Incantation,Joy Van,1989,true
 Indiana Jones and the Temple of Doom,Tengen,1989,false
-Jing Ke Xin Zhuan,SuperTone Electronics,1992,false
+Jing Ke Xin Zhuan,SuperTone Electronics,1992,true
 Joshua & the Battle of Jericho,Wisdom Tree,1992,false
-Jovial Race,Joy Van,1989,false
-Jurassic Boy,Sachen,1990,false
-Kart Fighter,Ge De Industry Co.,1993,false
+Jovial Race,Joy Van,1989,true
+Jurassic Boy,Sachen,1990,true
+Kart Fighter,Ge De Industry Co.,1993,true
 King Neptune's Adventure,Color Dreams,1990,false
 King of Kings: The Early Years,Wisdom Tree,1991,false
 Klax,Tengen,1990,false
 Krazy Kreatures,American Video Entertainment,1990,false
 Linus Spacehead's Cosmic Crusade,Camerica,1992,false
-Little Red Hood,HES,1989,false
-Locksmith,Sachen,1991,false
-Lucky 777,Sachen,1989,false
-Magic Cube,Sachen,1991,false
-Magic Jewelry,Hwang Shinwei,1990,false
-Magic Jewelry II,Hwang Shinwei,1991,false
-Magical Mathematics,Sachen,1990,false
-Magical Tower,Tin Chen,1992,false
-Mahjong Academy,Sachen,1992,false
-Mahjong Trap,Sachen,1990,false
-Mahjong Trap Plus,Sachen,1990,false
-The Mahjong World,Sachen,1990,false
+Little Red Hood,HES,1989,true
+Locksmith,Sachen,1991,true
+Lucky 777,Sachen,1989,true
+Magic Cube,Sachen,1991,true
+Magic Jewelry,Hwang Shinwei,1990,true
+Magic Jewelry II,Hwang Shinwei,1991,true
+Magical Mathematics,Sachen,1990,true
+Magical Tower,Tin Chen,1992,true
+Mahjong Academy,Sachen,1992,true
+Mahjong Trap,Sachen,1990,true
+Mahjong Trap Plus,Sachen,1990,true
+The Mahjong World,Sachen,1990,true
 Master Chu and the Drunkard Hu,Color Dreams,1989,false
-Maxi 15,American Video Entertainment,1992,false
+Maxi 15,American Video Entertainment,1992,true
 Mēi Shāo Nú Mèng Gōngchāng,Tin Chen,Unknown,false
-Memory Pair,Hwang Shinwei,1991,false
+Memory Pair,Hwang Shinwei,1991,true
 Menace Beach,Color Dreams,1990,false
 Mermaids of Atlantis,American Video Entertainment,1991,false
 Metal Fighter,Color Dreams,1989,false
 Micro Machines,Camerica,1992,false
-Middle School English II,Sachen,1989,false
+Middle School English II,Sachen,1989,true
 MiG-29: Soviet Fighter,Camerica,1991,false
-Millionaire,Sachen,1990,false
-Minesweeper,Sachen,1989,false
-Minesweeper 2,Sachen,1989,false
-Minesweeper 3,Sachen,1989,false
+Millionaire,Sachen,1990,true
+Minesweeper,Sachen,1989,true
+Minesweeper 2,Sachen,1989,true
+Minesweeper 3,Sachen,1989,true
 Mission Cobra,Bunch Games,1990,false
 Moon Ranger,Bunch Games,1990,false
 Ms. Pac-Man,Tengen,1990,false
-Myriad 6 in 1,Myriad,1992,false
-Olympic IQ,Sachen,1991,false
+Myriad 6 in 1,Myriad,1992,true
+Olympic IQ,Sachen,1991,true
 Operation Secret Storm,Color Dreams,1992,false
 Pac-Man,Tengen,1989,true
 Pac-Mania,Tengen,1990,false
 Peek-A-Boo Poker,Panesian,1991,false
-The Penguin and Seal,Sachen,1989,false
+The Penguin and Seal,Sachen,1989,true
 Pesterminator: The Western Exterminator,Color Dreams,1990,false
-Piano,Hwang Shinwei,Unknown,false
-Pipe V,Sachen,1990,false
-Poker II,Sachen,1990,false
-Poker III,Sachen,1991,false
-Poker Mahjong,Sachen,1991,false
-Pole Chudes,A. Chudov,1995,false
-Popo Team,Sachen,1991,false
+Piano,Hwang Shinwei,Unknown,true
+Pipe V,Sachen,1990,true
+Poker II,Sachen,1990,true
+Poker III,Sachen,1991,true
+Poker Mahjong,Sachen,1991,true
+Pole Chudes,A. Chudov,1995,true
+Popo Team,Sachen,1991,true
 The P'Radikus Conflict,Color Dreams,1990,false
-Punch Sprite,Hwang Shinwei,1990,false
+Punch Sprite,Hwang Shinwei,1990,true
 Puzzle,American Video Entertainment,1990,false
 Pyramid,American Video Entertainment,1990,false
-Pyramid II,Sachen,1990,false
-Q Boy,Sachen,1994,false
+Pyramid II,Sachen,1990,true
+Q Boy,Sachen,1994,true
 Quattro Adventure,Camerica,1991,false
 Quattro Arcade,Camerica,1992,false
 Quattro Sports,Camerica,1992,false
@@ -137,43 +137,43 @@ R.B.I. Baseball 2,Tengen,1990,false
 R.B.I. Baseball 3,Tengen,1991,false
 Road Runner,Tengen,1989,false
 Robodemons,Color Dreams,1990,false
-Rockball,Sachen,1993,false
-Rocman X,Sachen,1995,false
+Rockball,Sachen,1993,true
+Rocman X,Sachen,1995,true
 Rolling Thunder,Tengen,1989,false
 Secret Scout in the Temple of Demise,Color Dreams,1991,false
 Shinobi,Tengen,1989,false
 Shockwave,American Game Cartridges,1990,false
-Sidewinder,Joy Van,1989,false
+Sidewinder,Joy Van,1989,true
 Silent Assault,Color Dreams,1990,false
-Silver Eagle,Sachen,1994,false
+Silver Eagle,Sachen,1994,true
 Skull & Crossbones,Tengen,1990,false
 Solitaire,American Video Entertainment,1992,false
-Somari,Ge De Industry Co.,1994,false
+Somari,Ge De Industry Co.,1994,true
 Spiritual Warfare,Wisdom Tree,1992,false
-Strategist,Sachen,1991,false
-Street Heroes,Sachen,1995,false
+Strategist,Sachen,1991,true
+Street Heroes,Sachen,1995,true
 Stunt Kids,Camerica,1992,false
 Sunday Funday,Wisdom Tree,1995,false
-Super Mario World,J.Y. Company,1995,false
-Super Pang,Sachen,1991,false
-Super Pang II,Sachen,1992,false
+Super Mario World,J.Y. Company,1995,true
+Super Pang,Sachen,1991,true
+Super Pang II,Sachen,1992,true
 Super Sprint,Tengen,1989,false
 Tagin' Dragon,Bunch Games,1990,false
-Taiwan Mahjong,Sachen,1989,false
-Taiwan Mahjong II,Sachen,1992,false
-Tasac,Sachen,1992,false
+Taiwan Mahjong,Sachen,1989,true
+Taiwan Mahjong II,Sachen,1992,true
+Tasac,Sachen,1992,true
 Tetris,Tengen,1989,false
 Tiles of Fate,American Video Entertainment,1990,false
-Time Diver Avenger,Nitra Corporation,1994,false
+Time Diver Avenger,Nitra Corporation,1994,true
 Toobin',Tengen,1989,false
 Trolls on Treasure Island,American Video Entertainment,1992,false
-Twin Eagle,Joy Van,1989,false
-Ugadayka,A. Chudov,1995,false
+Twin Eagle,Joy Van,1989,true
+Ugadayka,A. Chudov,1995,true
 Ultimate League Soccer,American Video Entertainment,1991,false
 The Ultimate Stuntman,Camerica,1990,false
 Venice Beach Volleyball,American Video Entertainment,1991,false
 Vindicators,Tengen,1989,false
 Wally Bear and the NO! Gang,American Video Entertainment,1991,false
-Wild Ball,Hwang Shinwei,1991,false
-The World of Card Games,Sachen,1990,false
-Worm Visitor,Sachen,1992,false
+Wild Ball,Hwang Shinwei,1991,true
+The World of Card Games,Sachen,1990,true
+Worm Visitor,Sachen,1992,true

--- a/_data/unlicensed_games.csv
+++ b/_data/unlicensed_games.csv
@@ -91,7 +91,7 @@ Mahjong Trap Plus,Sachen,1990,true
 The Mahjong World,Sachen,1990,true
 Master Chu and the Drunkard Hu,Color Dreams,1989,false
 Maxi 15,American Video Entertainment,1992,true
-Mēi Shāo Nú Mèng Gōngchāng,Tin Chen,Unknown,false
+Mēi Shāo Nú Mèng Gōngchāng,Tin Chen,Unknown,true
 Memory Pair,Hwang Shinwei,1991,true
 Menace Beach,Color Dreams,1990,false
 Mermaids of Atlantis,American Video Entertainment,1991,false


### PR DESCRIPTION
The original Wikipedia list is just any unlicensed game released on NES, regardless of where it came out. I set (I think) all non-US games, and one game that's just a mulicart of other games in the list, to be hidden. 

also I realized after committing that I missed "Mēi Shāo Nú Mèng Gōngchāng", and couldn't figure out an easy way to go back without redoing all the changes, so please set that one to hidden too. Sorry, I haven't used github very much.

There's still a couple games on the list that probably won't be ranked because they're versions of other games on the list, but with these games removed, the remaining list should be pretty close to accurate. Looks like the full ranking will be roughly 780 games,